### PR TITLE
MVP for clickable buffer tabs

### DIFF
--- a/autoload/vem_tabline/buffers.vim
+++ b/autoload/vem_tabline/buffers.vim
@@ -31,6 +31,7 @@ function! vem_tabline#buffers#buffer_item.render(...)
     let end_discriminator_hl = get(a:, 2, '')
     let max_length = get(a:, 3, 0)
     let crop_direction = get(a:, 4, 'none')
+    let buffernr = get(a:, 5, 1)
 
     " discriminator
     if self.discriminator != '' && crop_direction == 'none'
@@ -40,7 +41,8 @@ function! vem_tabline#buffers#buffer_item.render(...)
     endif
 
     " build label
-    let label = ' ' . self.name . discriminator . self.flags . ' '
+    let clickable = has('tablineat') ? '%' . buffernr . '@GotoBuffer@' : ''
+    let label = ' ' . clickable . self.name . discriminator . self.flags . ' '
 
     " crop label
     if crop_direction == 'left'
@@ -50,6 +52,10 @@ function! vem_tabline#buffers#buffer_item.render(...)
     endif
 
     return label
+endfunction
+
+function! GotoBuffer(minwid, clicks, btn, modifiers) abort
+  execute 'buffer ' . a:minwid
 endfunction
 
 function! vem_tabline#buffers#section.update(buffer_nrs)
@@ -321,7 +327,7 @@ function! vem_tabline#buffers#section.render(max_length)
             let overflow = 0
         endif
 
-        let label = buffer_item.render(discriminator_hl, end_hl, overflow, crop_direction)
+        let label = buffer_item.render(discriminator_hl, end_hl, overflow, crop_direction, buffer_item.nr)
         let section .= prefix . label
     endfor
 


### PR DESCRIPTION

![Apr-22-2019 18-23-14](https://user-images.githubusercontent.com/23723357/56496406-dd299600-652b-11e9-8205-f77571d8a8b8.gif)

Hi, this pull request adds clickable buffers to vem-tabline (for neovim only),  just like in airline vim-airline/vim-airline/issues/369. I followed the minimal example mentioned in neovim/neovim/issues/7139, so before the tabline string might have looked like this 

```
%#VemTablineNormal#  vem_tabline.vim %#VemTablineSelected#  buffers.vim  %#VemTablineNormal#
```

now it looks like this

```
%#VemTablineNormal#  %1@GotoBuffer@vem_tabline.vim  %#VemTablineSelected# %2@GotoBuffer@buffers.vim  %#VemTablineNormal#
```

where GotoBuffer is a global function (you'll probably want to change the name and scope) tagged to each buffer tab

```vim
function! GotoBuffer(minwid, clicks, btn, modifiers) abort
  execute 'buffer ' . a:minwid
endfunction
```

and the `<number>` in each `%<number>@GotoBuffer@<tab name>` is the buffer number. If you click on the buffer tab `%2@GotoBuffer@buffers.vim`, 2 is the argument that gets passed as `a:minwid` to the function `GotoBuffer` and `:buffer 2` gets executed, jumping to the associated buffer 2.

This only works for neovim versions with the feature `has('tablineat')`, so there's a check for that right before creating the label inside `function! vem_tabline#buffers#buffer_item.render(...)`. If 'tablineat' is not present, the extra stuff doesn't get prepended to the label so it should work like before. 

I think I should leave it up to you how to refactor this code, cos I kind of just threw together the minimum amount of code that would make it work.