### PR TITLE
add support for vim-devicons

### DIFF
--- a/autoload/vem_tabline/buffers.vim
+++ b/autoload/vem_tabline/buffers.vim
@@ -138,6 +138,9 @@ function! vem_tabline#buffers#section.generate_labels_without_tagnr() abort
             let dirname = buffer_item.path_parts[buffer_item.path_index]
             let buffer_item.discriminator = g:vem_tabline_location_symbol . dirname
         endif
+        if exists('*WebDevIconsGetFileTypeSymbol')  " support for vim-devicons
+            let buffer_item.discriminator .= ' ' . WebDevIconsGetFileTypeSymbol(buffer_item.name)
+        endif
 
         " get flags
         if buffer_item.modified


### PR DESCRIPTION
A very simple proposal to add support for [vim-devicons](https://github.com/ryanoasis/vim-devicons) in the buffer names. This should be transparent if vim-devicons is loaded and will not impact users who don't use it.