### PR TITLE
enabling syntax hi for modified buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ VemTablineSeparator        | TabLineFill | '+X more' text
 VemTablinePartialName      | TabLine     | Partially displayed buffer at the edge of the tabline
 VemTablineTabSelected      | TabLineSel  | Selected tab
 VemTablineTabNormal        | TabLineFill | Non selected tab
+VemTablineModified         | TabLineFill | Non-selected modified buffers
+VemTablineSelectedModified | TabLineSel  | Currently selected modified buffer
 
 For example, with the following code you can configure your tabline colors using
 different shades of grey:

--- a/autoload/vem_tabline/buffers.vim
+++ b/autoload/vem_tabline/buffers.vim
@@ -291,19 +291,30 @@ function! vem_tabline#buffers#section.get_tabline() abort
         let last_one = buffer_index == buffer_range[-1]
 
         " label
-        if buffer_item.current
+        if buffer_item.current && buffer_item.modified
+            let section .= '%#VemTablineSelectedModified# '
+            let section .= buffer_item.render('SelectedModified')
+        elseif buffer_item.current
             let section .= '%#VemTablineSelected# '
             let section .= buffer_item.render('Selected')
+        elseif buffer_item.shown && buffer_item.modified
+            let section .= ' %#VemTablineShownModified#'
+            let section .= buffer_item.render('ShownModified')
         elseif buffer_item.shown
             let section .= ' %#VemTablineShown#'
             let section .= buffer_item.render('Shown')
+        elseif buffer_item.modified
+            let section .= ' %#VemTablineModified#'
+            let section .= buffer_item.render('Modified')
         else
             let section .= ' %#VemTablineNormal#'
             let section .= buffer_item.render('')
         endif
 
         " last right label margin
-        if last_one
+        if last_one && buffer_item.modified
+            let section .= ' %#VemTablineModified#'
+        elseif last_one
             let section .= ' %#VemTablineNormal#'
         endif
     endfor

--- a/plugin/vem_tabline.vim
+++ b/plugin/vem_tabline.vim
@@ -42,6 +42,15 @@ highlight default link VemTablineSeparator TabLineFill
 highlight default link VemTablineTabNormal TabLineFill
 highlight default link VemTablineTabSelected TabLineSel
 highlight default link VemTabline VemTablineNormal
+highlight default link VemTablineModified TabLine
+highlight default link VemTablineNumberModified TabLine
+highlight default link VemTablineSelectedModified TabLineSel
+highlight default link VemTablineNumberSelectedModified TabLineSel
+highlight default link VemTablineLocationModified VemTablineModified
+highlight default link VemTablineLocationSelectedModified VemTablineSelectedModified
+highlight default link VemTablineShownModified VemTablineModified
+highlight default link VemTablineNumberShownModified VemTablineModified
+highlight default link VemTablineLocationShownModified VemTablineModified
 
 " Functions
 


### PR DESCRIPTION
Although having a star `*` flag at the end of the modified buffers (current situation)  is a good enough feature for those with `set hidden` in their `vimrc`, it was a bit hard for me to find them on the screen without having a different color than the other tabs. I thought maybe some other Vem Tabline user might also expect more from the modified and left alone buffers in terms of making themselves more visible to the user.
Mines look like this now:
![Selection_359](https://user-images.githubusercontent.com/1807140/101273721-36dde300-3798-11eb-9c70-2e3e8f8e1480.png)


only tested on terminal vim with a certain colorscheme